### PR TITLE
Parameters flag in build_loadable_extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,8 @@ add_custom_command(
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND sh pgconfigure)
 
-build_loadable_extension(${TARGET_NAME} postgres_scanner.cpp
-        ${LIBPG_SOURCES_FULLPATH})
+set(PARAMETERS "-no-warnings")
+build_loadable_extension(${TARGET_NAME} ${PARAMETERS} postgres_scanner.cpp ${LIBPG_SOURCES_FULLPATH})
 
 if(WIN32)
   target_link_libraries(${TARGET_NAME}_loadable_extension wsock32 ws2_32 wldap32 secur32)


### PR DESCRIPTION
This fixes an upcoming PR that introduces the parameters field to the `build_loadable_extension`. This field encoded as a string so as to be extensible in the future, and replaces the (previously borked) IGNORE_WARNINGS field (see duckdb/duckdb#4394).