### PR TITLE
Fix SELECT count(*)

### DIFF
--- a/test/postgres_scanner/count_star.test
+++ b/test/postgres_scanner/count_star.test
@@ -1,0 +1,13 @@
+statement ok
+LOAD 'build/release/extension/postgres_scanner/postgres_scanner.duckdb_extension';
+
+statement ok
+pragma enable_verification
+
+statement ok
+CALL postgres_attach('dbname=postgresscanner');
+
+query I
+select count(*) from cars;
+----
+4


### PR DESCRIPTION
This query only requires counting rows, so it is optimized into selecting a rowid column from the underlying table. In case of the Postgres table, this gets deparsed into selecting the first column. If it happens to be a text column, we then try to insert it into the rowid output vector which is int, and fail with an assertion because of type mismatch.

Instead of this, deparse this case into SELECT NULL FROM postgres_table. This is enough for counting the rows.