### PR TITLE
support uuid type

### DIFF
--- a/all_pg_types.sql
+++ b/all_pg_types.sql
@@ -18,7 +18,8 @@ CREATE TABLE pg_bytetypes (
 	varchar_9_col varchar(9),
 	text_col text,
 	blob_col bytea,
-	json_col json);
+	json_col json,
+	uuid_col uuid);
 
 CREATE TABLE pg_datetypes (
 	date_col date,
@@ -34,11 +35,11 @@ INSERT INTO pg_numtypes (bool_col, smallint_col, integer_col, bigint_col, float_
 	(true, 42, 42, 42, 42.01, 42.01, 42.01), 
 	(NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-INSERT INTO pg_bytetypes (char_1_col, char_9_col, varchar_1_col, varchar_9_col, text_col, blob_col, json_col) VALUES 
-	('a', '', '', '', '', '', '42'), 
-	('a', 'aaaaaaaaa', 'a', 'aaaaaaaaa', 'dpfkg', 'dpfkg', '{"a":42}'), 
-	('Z', 'ZZZZZZZZZ', 'Z', 'ZZZZZZZZZ', 'dpfkg', 'dpfkg', '{"a":42}'), 
-	(NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO pg_bytetypes (char_1_col, char_9_col, varchar_1_col, varchar_9_col, text_col, blob_col, json_col, uuid_col) VALUES
+	('a', '', '', '', '', '', '42', '00000000-0000-0000-0000-000000000000'),
+	('a', 'aaaaaaaaa', 'a', 'aaaaaaaaa', 'dpfkg', 'dpfkg', '{"a":42}', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+	('Z', 'ZZZZZZZZZ', 'Z', 'ZZZZZZZZZ', 'dpfkg', 'dpfkg', '{"a":42}', 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11'),
+	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 
 SET TIMEZONE='Asia/Kathmandu'; -- UTC - 05:45 hell yeah!

--- a/postgres_scanner.cpp
+++ b/postgres_scanner.cpp
@@ -196,6 +196,8 @@ static LogicalType DuckDBType(PostgresColumnInfo &info, PGconn *conn) {
 		return LogicalType::TIMESTAMP_TZ;
 	} else if (pgtypename == "interval") {
 		return LogicalType::INTERVAL;
+	} else if (pgtypename == "uuid") {
+		return LogicalType::UUID;
 	} else {
 		throw IOException("Unsupported Postgres type %s", pgtypename);
 	}
@@ -715,6 +717,22 @@ static void ProcessValue(data_ptr_t value_ptr, idx_t value_len, const PostgresBi
 		FlatVector::GetData<interval_t>(out_vec)[output_offset] = res;
 		break;
 	}
+
+	case LogicalTypeId::UUID: {
+		D_ASSERT(bind_data->columns[col_idx].attlen == 2 * sizeof(int64_t));
+		D_ASSERT(value_len == 2 * sizeof(int64_t));
+		D_ASSERT(bind_data->columns[col_idx].atttypmod == -1);
+
+		hugeint_t res;
+
+		auto upper = ntohll(Load<uint64_t>(value_ptr));
+		res.upper = upper ^ (int64_t(1) << 63);
+		res.lower = ntohll(Load<uint64_t>(value_ptr + sizeof(uint64_t)));
+
+		FlatVector::GetData<hugeint_t>(out_vec)[output_offset] = res;
+		break;
+	}
+
 	default:
 		throw InternalException("Unsupported Type %s", type.ToString());
 	}

--- a/test/postgres_scanner/types.test
+++ b/test/postgres_scanner/types.test
@@ -15,13 +15,13 @@ False	-42	-42	-42	-42.009998	-42.010000	-42.0
 True	42	42	42	42.009998	42.010000	42.0
 NULL	NULL	NULL	NULL	NULL	NULL	NULL
 
-query IIIIIII
+query IIIIIIII
 select * from pg_bytetypes;
 ----
-a	         	(empty)	(empty)	(empty)	(empty)	42
-a	aaaaaaaaa	a	aaaaaaaaa	dpfkg	dpfkg	{"a":42}
-Z	ZZZZZZZZZ	Z	ZZZZZZZZZ	dpfkg	dpfkg	{"a":42}
-NULL	NULL	NULL	NULL	NULL	NULL	NULL
+a	         	(empty)	(empty)	(empty)	(empty)	42	00000000-0000-0000-0000-000000000000
+a	aaaaaaaaa	a	aaaaaaaaa	dpfkg	dpfkg	{"a":42}	a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+Z	ZZZZZZZZZ	Z	ZZZZZZZZZ	dpfkg	dpfkg	{"a":42}	a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
 
 query IIIII
 select * from pg_datetypes;


### PR DESCRIPTION
Uses `hugeint_t` data type to represent UUID from postgres.
Adds test cases for "nil uuid", lowercase, uppercase, and `NULL`.
Fixes #25 