### PR TITLE
Fix selecting numeric

### DIFF
--- a/create-postgres-tables.sh
+++ b/create-postgres-tables.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 echo "
-CREATE SCHEMA tpch; 
+CREATE SCHEMA tpch;
 CREATE SCHEMA tpcds;
 CALL dbgen(sf=0.01, schema='tpch');
 CALL dsdgen(sf=0.01, schema='tpcds');
 EXPORT DATABASE '/tmp/postgresscannertmp';
 " | \
-./build/release/duckdb 
+./build/release/duckdb
 
 dropdb --if-exists postgresscanner
 createdb postgresscanner
@@ -44,6 +44,7 @@ insert into cars(brand, model, color)
 
 create table intervals as select '42 day'::INTERVAL interval_days UNION ALL SELECT '42 month'::INTERVAL UNION ALL SELECT '42 year'::INTERVAL UNION ALL SELECT  '42 minute'::INTERVAL UNION ALL SELECT  '42 second'::INTERVAL UNION ALL SELECT '0.42 second'::INTERVAL UNION ALL SELECT '-42 day'::INTERVAL interval_days  UNION ALL SELECT NULL::INTERVAL;
 
+create table numerics as select n from (values (32.8875000), (-32.8875000), (10000), (1000), (100), (10), (1), (0.1), (0.01), (0.001), (0.0001), (0.00001), (0.000001), (0.0000001), (10001), (1.0001), (0.0001001), (10001.0001), (1.0001001), (10001.0001001), (0)) t(n);
 " |  psql -d postgresscanner
 
 

--- a/create-postgres-tables.sh
+++ b/create-postgres-tables.sh
@@ -44,7 +44,8 @@ insert into cars(brand, model, color)
 
 create table intervals as select '42 day'::INTERVAL interval_days UNION ALL SELECT '42 month'::INTERVAL UNION ALL SELECT '42 year'::INTERVAL UNION ALL SELECT  '42 minute'::INTERVAL UNION ALL SELECT  '42 second'::INTERVAL UNION ALL SELECT '0.42 second'::INTERVAL UNION ALL SELECT '-42 day'::INTERVAL interval_days  UNION ALL SELECT NULL::INTERVAL;
 
-create table numerics as select n from (values (32.8875000), (-32.8875000), (10000), (1000), (100), (10), (1), (0.1), (0.01), (0.001), (0.0001), (0.00001), (0.000001), (0.0000001), (10001), (1.0001), (0.0001001), (10001.0001), (1.0001001), (10001.0001001), (0)) t(n);
+create table numerics (n numeric(12, 7));
+insert into numerics values (32.8875000), (-32.8875000), (10000), (1000), (100), (10), (1), (0.1), (0.01), (0.001), (0.0001), (0.00001), (0.000001), (0.0000001), (10001), (1.0001), (0.0001001), (10001.0001), (1.0001001), (10001.0001001), (0);
 " |  psql -d postgresscanner
 
 

--- a/test/postgres_scanner/numeric.test
+++ b/test/postgres_scanner/numeric.test
@@ -1,0 +1,33 @@
+statement ok
+LOAD 'build/release/extension/postgres_scanner/postgres_scanner.duckdb_extension';
+
+statement ok
+pragma enable_verification;
+
+statement ok
+CALL postgres_attach('dbname=postgresscanner');
+
+query I
+select * from numerics;
+----
+32.8875000
+-32.8875000
+10000.0000000
+1000.0000000
+100.0000000
+10.0000000
+1.0000000
+0.1000000
+0.0100000
+0.0010000
+0.0001000
+0.0000100
+0.0000010
+0.0000001
+10001.0000000
+1.0001000
+0.0001001
+10001.0001000
+1.0001001
+10001.0001001
+0.0000000


### PR DESCRIPTION
Fixes #69
I tested this fix as follows.

In Postgres
```sql
postgres=# create table test (n numeric(12, 7));
CREATE TABLE
postgres=# insert into test values (32.8875000), (-32.8875000), (10000), (1000), (100), (10), (1), (0.1), (0.01), (0.001), (0.0001), (0.00001), (0.000001), (0.0000001), (10001), (1.0001), (0.0001001), (10001.0001), (1.0001001), (10001.0001001), (0);
INSERT 0 21
```

In DuckDB
```sql
D load 'build/debug/extension/postgres_scanner/postgres_scanner.duckdb_extension';
D call postgres_attach(...);
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ 0 rows  │
└─────────┘
D select * from test;
┌───────────────┐
│       n       │
│ decimal(12,7) │
├───────────────┤
│    32.8875000 │
│   -32.8875000 │
│ 10000.0000000 │
│  1000.0000000 │
│   100.0000000 │
│    10.0000000 │
│     1.0000000 │
│     0.1000000 │
│     0.0100000 │
│     0.0010000 │
│     0.0001000 │
│     0.0000100 │
│     0.0000010 │
│     0.0000001 │
│ 10001.0000000 │
│     1.0001000 │
│     0.0001001 │
│ 10001.0001000 │
│     1.0001001 │
│ 10001.0001001 │
│     0.0000000 │
├───────────────┤
│    21 rows    │
└───────────────┘
```

It seems to work well.