### PR TITLE
Safe unique ptr

### DIFF
--- a/concurrency_test.cpp
+++ b/concurrency_test.cpp
@@ -31,7 +31,7 @@ struct PGQueryResult {
 };
 
 static void PGExec(PGconn *conn, string q) {
-	auto res = make_unique<PGQueryResult>();
+	auto res = make_uniq<PGQueryResult>();
 	res->res = PQexec(conn, q.c_str());
 
 	if (!res->res) {
@@ -43,7 +43,7 @@ static void PGExec(PGconn *conn, string q) {
 }
 
 static unique_ptr<PGQueryResult> PGQuery(PGconn *conn, string q) {
-	auto res = make_unique<PGQueryResult>();
+	auto res = make_uniq<PGQueryResult>();
 	res->res = PQexec(conn, q.c_str());
 
 	if (!res->res) {

--- a/postgres_scanner.cpp
+++ b/postgres_scanner.cpp
@@ -140,7 +140,7 @@ static PGconn *PGConnect(string &dsn) {
 }
 
 static unique_ptr<PGQueryResult> PGQuery(PGconn *conn, string q, ExecStatusType response_code = PGRES_TUPLES_OK) {
-	auto res = make_unique<PGQueryResult>(PQexec(conn, q.c_str()));
+	auto res = make_uniq<PGQueryResult>(PQexec(conn, q.c_str()));
 	if (!res->res || PQresultStatus(res->res) != response_code) {
 		throw IOException("Unable to query Postgres: %s %s", string(PQerrorMessage(conn)),
 		                  string(PQresultErrorMessage(res->res)));
@@ -224,7 +224,7 @@ static LogicalType DuckDBType(PostgresColumnInfo &info, PGconn *conn, ClientCont
 static unique_ptr<FunctionData> PostgresBind(ClientContext &context, TableFunctionBindInput &input,
                                              vector<LogicalType> &return_types, vector<string> &names) {
 
-	auto bind_data = make_unique<PostgresBindData>();
+	auto bind_data = make_uniq<PostgresBindData>();
 
 	bind_data->dsn = input.inputs[0].GetValue<string>();
 	bind_data->schema_name = input.inputs[1].GetValue<string>();
@@ -929,7 +929,7 @@ static idx_t PostgresMaxThreads(ClientContext &context, const FunctionData *bind
 
 static unique_ptr<GlobalTableFunctionState> PostgresInitGlobalState(ClientContext &context,
                                                                     TableFunctionInitInput &input) {
-	return make_unique<PostgresGlobalState>(PostgresMaxThreads(context, input.bind_data));
+	return make_uniq<PostgresGlobalState>(PostgresMaxThreads(context, input.bind_data));
 }
 
 static bool PostgresParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,
@@ -960,7 +960,7 @@ static unique_ptr<LocalTableFunctionState> PostgresInitLocalState(ExecutionConte
 	auto bind_data = (const PostgresBindData *)input.bind_data;
 	auto &gstate = (PostgresGlobalState &)*global_state;
 
-	auto local_state = make_unique<PostgresLocalState>();
+	auto local_state = make_uniq<PostgresLocalState>();
 	local_state->column_ids = input.column_ids;
 	local_state->conn = PostgresScanConnect(bind_data->dsn, bind_data->in_recovery, bind_data->snapshot);
 	local_state->filters = input.filters;
@@ -1053,7 +1053,7 @@ struct AttachFunctionData : public TableFunctionData {
 static unique_ptr<FunctionData> AttachBind(ClientContext &context, TableFunctionBindInput &input,
                                            vector<LogicalType> &return_types, vector<string> &names) {
 
-	auto result = make_unique<AttachFunctionData>();
+	auto result = make_uniq<AttachFunctionData>();
 	result->dsn = input.inputs[0].GetValue<string>();
 
 	for (auto &kv : input.named_parameters) {

--- a/postgres_scanner.cpp
+++ b/postgres_scanner.cpp
@@ -303,7 +303,7 @@ ORDER BY attnum;
 		auto needs_cast = duckdb_type == LogicalType::INVALID;
 		bind_data->needs_cast.push_back(needs_cast);
 		if (!needs_cast) {
-			bind_data->types.push_back(move(duckdb_type));
+			bind_data->types.push_back(std::move(duckdb_type));
 		} else {
 			bind_data->types.push_back(LogicalType::VARCHAR);
 		}
@@ -315,7 +315,7 @@ ORDER BY attnum;
 	return_types = bind_data->types;
 	names = bind_data->names;
 
-	return move(bind_data);
+	return std::move(bind_data);
 }
 
 static string TransformFilter(string &column_name, TableFilter &filter);
@@ -967,7 +967,7 @@ static unique_ptr<LocalTableFunctionState> PostgresInitLocalState(ExecutionConte
 	if (!PostgresParallelStateNext(context.client, input.bind_data, *local_state, gstate)) {
 		local_state->done = true;
 	}
-	return move(local_state);
+	return std::move(local_state);
 }
 
 static void PostgresScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
@@ -1070,7 +1070,7 @@ static unique_ptr<FunctionData> AttachBind(ClientContext &context, TableFunction
 
 	return_types.push_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");
-	return move(result);
+	return std::move(result);
 }
 
 static void AttachFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {


### PR DESCRIPTION
This PR is made in preparation of migrating DuckDB to use it's own `unique_ptr` implementation
Removing the use of `std::make_unique` and changing it to `duckdb::make_uniq`
`make_unique` -> `make_uniq` is done to avoid clashing with the std namespace and having to explicitly qualify every call.