### PR TITLE
Fix enum array support

### DIFF
--- a/postgres_scanner.cpp
+++ b/postgres_scanner.cpp
@@ -293,6 +293,7 @@ ORDER BY attnum;
 		info.type_info.typtype = res->GetString(row, 5);
 		info.typelem = res->GetInt64(row, 6);
 
+		info.elem_info.nspname = res->GetString(row, 2);
 		info.elem_info.typname = res->GetString(row, 7);
 		info.elem_info.typlen = res->GetInt64(row, 8);
 		info.elem_info.typtype = res->GetString(row, 9);
@@ -835,11 +836,11 @@ static void ProcessValue(const LogicalType &type, const PostgresTypeInfo *type_i
 				continue;
 			}
 
-			if (elem_info->typlen > 0 && ele_len != elem_info->typlen) {
-				throw InvalidInputException(
-				    "Expected to read a Postgres list value of length %d, but only have size %d", elem_info->typlen,
-				    ele_len);
-			}
+			// if (elem_info->typlen > 0 && ele_len != elem_info->typlen) {
+			// 	throw InvalidInputException(
+			// 	    "Expected to read a Postgres list value of length %d, but only have size %d", elem_info->typlen,
+			// 	    ele_len);
+			// }
 			ProcessValue(ListType::GetChildType(type), elem_info, atttypmod, 0, nullptr, value_ptr, ele_len, child_vec,
 			             child_offset + child_idx);
 			value_ptr += ele_len;

--- a/postgres_scanner.cpp
+++ b/postgres_scanner.cpp
@@ -836,11 +836,6 @@ static void ProcessValue(const LogicalType &type, const PostgresTypeInfo *type_i
 				continue;
 			}
 
-			// if (elem_info->typlen > 0 && ele_len != elem_info->typlen) {
-			// 	throw InvalidInputException(
-			// 	    "Expected to read a Postgres list value of length %d, but only have size %d", elem_info->typlen,
-			// 	    ele_len);
-			// }
 			ProcessValue(ListType::GetChildType(type), elem_info, atttypmod, 0, nullptr, value_ptr, ele_len, child_vec,
 			             child_offset + child_idx);
 			value_ptr += ele_len;

--- a/test/all_pg_types.sql
+++ b/test/all_pg_types.sql
@@ -27,6 +27,8 @@ CREATE TABLE pg_datetypes (
 	timestamptz_col timestamptz
 );
 
+CREATE TYPE enum_type AS ENUM ('foo', 'bar', 'baz');
+
 CREATE TABLE pg_numarraytypes (
                              bool_col _bool,
                              smallint_col _int2,
@@ -54,6 +56,9 @@ CREATE TABLE pg_datearraytypes (
                               timestamp_col _timestamp,
                               timestamptz_col _timestamptz);
 
+CREATE TABLE pg_enumarraypgtypes (
+							  enum_col _enum_type);
+
 INSERT INTO pg_numtypes (bool_col, smallint_col, integer_col, bigint_col, float_col, double_col, decimal_col, udecimal_col) VALUES
 	(false, 0, 0, 0, 0, 0, 0, 0),
 	(false, -42, -42, -42, -42.01, -42.01, -42.01, -42.01),
@@ -80,3 +85,6 @@ VALUES ('{a, Z, NULL}', '{a, Z, NULL}', '{aaaa, ZZZZ, NULL}', '{aaaa, ZZZZ, NULL
 
 insert into pg_datearraytypes (date_col, time_col,timetz_col, timestamp_col, timestamptz_col)
 VALUES ('{2019-11-26, 2021-03-01, NULL}','{14:42:43, 12:45:01, NULL}','{14:42:43, 12:45:01, NULL}','{2019-11-26T12:45:01, 2021-03-01T12:45:01, NULL}','{2019-11-26T12:45:01, 2021-03-01T12:45:01, NULL}'), (NULL, NULL, NULL, NULL, NULL);
+
+insert into pg_enumarraypgtypes (enum_col)
+VALUES ('{}'), ('{foo}'), ('{foo, bar}'), ('{foo, bar, baz}'), ('{foo, bar, baz, NULL}'), (NULL); 

--- a/test/all_pg_types.sql
+++ b/test/all_pg_types.sql
@@ -56,7 +56,7 @@ CREATE TABLE pg_datearraytypes (
                               timestamp_col _timestamp,
                               timestamptz_col _timestamptz);
 
-CREATE TABLE pg_enumarraypgtypes (
+CREATE TABLE pg_enumarraytypes (
 							  enum_col _enum_type);
 
 INSERT INTO pg_numtypes (bool_col, smallint_col, integer_col, bigint_col, float_col, double_col, decimal_col, udecimal_col) VALUES
@@ -86,5 +86,5 @@ VALUES ('{a, Z, NULL}', '{a, Z, NULL}', '{aaaa, ZZZZ, NULL}', '{aaaa, ZZZZ, NULL
 insert into pg_datearraytypes (date_col, time_col,timetz_col, timestamp_col, timestamptz_col)
 VALUES ('{2019-11-26, 2021-03-01, NULL}','{14:42:43, 12:45:01, NULL}','{14:42:43, 12:45:01, NULL}','{2019-11-26T12:45:01, 2021-03-01T12:45:01, NULL}','{2019-11-26T12:45:01, 2021-03-01T12:45:01, NULL}'), (NULL, NULL, NULL, NULL, NULL);
 
-insert into pg_enumarraypgtypes (enum_col)
+insert into pg_enumarraytypes (enum_col)
 VALUES ('{}'), ('{foo}'), ('{foo, bar}'), ('{foo, bar, baz}'), ('{foo, bar, baz, NULL}'), (NULL); 


### PR DESCRIPTION
This pull request fixes an issue where enum array columns would fail with because of an empty namespace value:

```
07:23:45     ERROR:  syntax error at or near "."
07:23:45    LINE 1: SELECT unnest(enum_range(NULL::.my_enum_type))
```

For some reason, there is a condition that throws an error if an array value's length doesn't match its `typlen` value. This doesn't make sense since Postgres arrays are variable length. Existing array tests seem to pass without it.

## Testing

I added some additional unit tests for enum arrays. Github Actions was slow to start so pasting test output from my machine:

```
[100%] Built target postgres_scanner_loadable_extension
./build/release/test/unittest --test-dir . "[postgres_scanner]"
Filters: [postgres_scanner]
[17/17] (100%): test/postgres_scanner/bug76.test
===============================================================================
All tests passed (30776 assertions in 17 test cases)
```